### PR TITLE
Fix image references in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.15 as builder
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.15 as builder
 
 WORKDIR /hypershift
 
@@ -6,6 +6,6 @@ COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o bin/hypershift-operator hypershift-operator/main.go
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o bin/control-plane-operator control-plane-operator/main.go
 
-FROM registry.svc.ci.openshift.org/ocp/4.6:base
+FROM quay.io/openshift/origin-base:4.6
 COPY --from=builder /hypershift/bin/hypershift-operator /usr/bin/hypershift-operator
 COPY --from=builder /hypershift/bin/control-plane-operator /usr/bin/control-plane-operator


### PR DESCRIPTION
Switch to the CI version of release:golang-1.15 since the docker.io one is going to have restrictions on pulling
Switch to the public version of the base image