### PR TITLE
Include OAuth deployment in ROKS manifests

### DIFF
--- a/hypershift-operator/assets/controlplane/roks/control-plane-operator/cp-operator-role.yaml
+++ b/hypershift-operator/assets/controlplane/roks/control-plane-operator/cp-operator-role.yaml
@@ -24,3 +24,16 @@ rules:
   - update
   - list
   - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  - routes/custom-host
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - create
+  - delete

--- a/hypershift-operator/controllers/controlplane.go
+++ b/hypershift-operator/controllers/controlplane.go
@@ -39,6 +39,7 @@ const (
 	externalOauthPort         = 8443
 	APIServerPort             = 6443
 	DefaultAPIServerIPAddress = "172.20.0.1"
+	oauthBrandingManifest     = "v4-0-config-system-branding.yaml"
 )
 
 var (
@@ -178,12 +179,27 @@ func (r *HostedControlPlaneReconciler) ensureControlPlane(ctx context.Context, h
 	}
 	params.OpenshiftAPIServerCABundle = base64.StdEncoding.EncodeToString(caBytes)
 
-	if err = rokscp.RenderClusterManifests(&rokscp.ClusterParams{ClusterParams: *params}, releaseInfo, pullSecretFile, manifestsDir, false, false); err != nil {
+	if err = rokscp.RenderClusterManifests(&rokscp.ClusterParams{ClusterParams: *params}, releaseInfo, pullSecretFile, manifestsDir, true, false); err != nil {
 		return fmt.Errorf("failed to render roks manifests for cluster: %w", err)
 	}
 
 	if err = hypershiftcp.RenderClusterManifests(params, releaseInfo, pullSecretFile, pkiDir, manifestsDir, true, true, true, true); err != nil {
 		return fmt.Errorf("failed to render hypershift manifests for cluster: %w", err)
+	}
+
+	manifestBytes, err := ioutil.ReadFile(filepath.Join(manifestsDir, oauthBrandingManifest))
+	if err != nil {
+		return fmt.Errorf("failed to read manifest %s: %w", oauthBrandingManifest, err)
+	}
+	manifestObj := &unstructured.Unstructured{}
+	if err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(string(manifestBytes)), 100).Decode(manifestObj); err != nil {
+		return fmt.Errorf("failed to decode manifest %s: %w", oauthBrandingManifest, err)
+	}
+	manifestObj.SetNamespace(name)
+	if err = r.Create(context.TODO(), manifestObj); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to apply manifest %s: %w", oauthBrandingManifest, err)
+		}
 	}
 
 	for _, name := range excludeManifests {


### PR DESCRIPTION
Adds code to create the OAuth branding secret and fixes up the control plane operator role