### PR TITLE
Add a cluster-api deployment based on a published image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,6 @@ Run the operator:
 $ bin/hypershift-operator run --control-plane-operator-image quay.io/hypershift/hypershift:latest
 ```
 
-Run the sigs.k8s.io cluster API controller:
-```
-$ git clone git@github.com:kubernetes-sigs/cluster-api.git
-$ cd cluster-api && make manager-core
-$ ./bin/manager
-```
-
 Create a cluster, referencing a release image present in the `release-images` configmap
 previously created:
 

--- a/manifests/cluster-api-clusterrole.yaml
+++ b/manifests/cluster-api-clusterrole.yaml
@@ -1,0 +1,77 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: cluster-api
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - bootstrap.cluster.x-k8s.io
+  - controlplane.cluster.x-k8s.io
+  - infrastructure.cluster.x-k8s.io
+  - machines.cluster.x-k8s.io
+  - exp.infrastructure.cluster.x-k8s.io
+  - addons.cluster.x-k8s.io
+  - exp.cluster.x-k8s.io
+  - cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - hostedcontrolplanes
+  - hostedcontrolplanes/status
+  - guestclusters
+  - guestclusters/status
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch

--- a/manifests/cluster-api-clusterrolebinding.yaml
+++ b/manifests/cluster-api-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-api
+subjects:
+- kind: ServiceAccount
+  name: cluster-api
+  namespace: hypershift

--- a/manifests/cluster-api-deployment.yaml
+++ b/manifests/cluster-api-deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: hypershift
+  name: cluster-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: cluster-api
+  template:
+    metadata:
+      labels:
+        name: cluster-api
+    spec:
+      serviceAccountName: cluster-api
+      containers:
+      - name: manager
+        image: quay.io/hypershift/cluster-api:hypershift
+        command:
+        - /manager
+        args:
+        - --namespace=hypershift
+        - --v=4

--- a/manifests/cluster-api-serviceaccount.yaml
+++ b/manifests/cluster-api-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: hypershift
+  name: cluster-api

--- a/manifests/hypershift.openshift.io_crds.yaml
+++ b/manifests/hypershift.openshift.io_crds.yaml
@@ -27,14 +27,10 @@ spec:
         description: GuestCluster is the Schema for the GuestCluster API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -44,8 +40,7 @@ spec:
               computeReplicas:
                 type: integer
               controlPlaneEndpoint:
-                description: ControlPlaneEndpoint represents the endpoint used to
-                  communicate with the control plane.
+                description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
                 properties:
                   host:
                     description: Host is the hostname on which the API server is serving.
@@ -106,14 +101,10 @@ spec:
         description: HostedControlPlane defines the desired state of HostedControlPlane
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -158,8 +149,7 @@ spec:
                 type: object
               ready:
                 default: false
-                description: Ready denotes that the HostedControlPlane API Server
-                  is ready to receive requests
+                description: Ready denotes that the HostedControlPlane API Server is ready to receive requests
                 type: boolean
             required:
             - controlPlaneEndpoint
@@ -209,14 +199,10 @@ spec:
         description: NodePool defines the desired state of NodePool
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -234,22 +220,18 @@ spec:
                 - min
                 type: object
               clusterName:
-                description: ClusterName is the name of the Cluster this object belongs
-                  to.
+                description: ClusterName is the name of the Cluster this object belongs to.
                 type: string
               nodeCount:
                 type: integer
               platform:
-                description: NodePoolPlatform is the platform-specific configuration
-                  for a node pool. Only one of the platforms should be set.
+                description: NodePoolPlatform is the platform-specific configuration for a node pool. Only one of the platforms should be set.
                 properties:
                   aws:
-                    description: AWS is the configuration used when installing on
-                      AWS.
+                    description: AWS is the configuration used when installing on AWS.
                     properties:
                       instanceType:
-                        description: InstanceType defines the ec2 instance type. eg.
-                          m4-large
+                        description: InstanceType defines the ec2 instance type. eg. m4-large
                         type: string
                     required:
                     - instanceType
@@ -311,14 +293,10 @@ spec:
         description: OpenShiftCluster is the Schema for the openshiftclusters API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object


### PR DESCRIPTION
Roll out the cluster-api manager as a deployment in the hypershift namespace
as a sibling to the operator. The default is to use our latest published image.