### PR TITLE
Improve control plane operator image detection for local development

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -17,7 +17,7 @@ $ make build
 
 $ make install PROFILE=development
 
-$ bin/hypershift-operator run --release-info config/bases/release-info.json
+$ make run-local
 ```
 
 Or you might want to run your own image in the cluster to do integration

--- a/Makefile
+++ b/Makefile
@@ -77,3 +77,6 @@ docker-push:
 
 release-info-data:
 	oc adm release info --output json > config/hypershift-operator/release-info.json
+
+run-local:
+	bin/hypershift-operator run --release-info config/hypershift-operator/release-info.json

--- a/config/hypershift-operator/operator-deployment.yaml
+++ b/config/hypershift-operator/operator-deployment.yaml
@@ -30,12 +30,3 @@ spec:
         args:
         - run
         - --release-info=/etc/release-info/release-info.json
-        env:
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: MY_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace


### PR DESCRIPTION
Detect the control plane operator image using the operator deployment rather
than the pod, because the deployment can be assumed to exist (even if scaled
down) when using local workflows. This obviates the need for passing the
--control-plane-operator-image flag in typical development workflows.