### PR TITLE
update rbac apiVersion to avoid deprecation warning

### DIFF
--- a/config/cluster-api/manager-clusterrolebinding.yaml
+++ b/config/cluster-api/manager-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cluster-api

--- a/config/hypershift-operator/operator-clusterrolebinding.yaml
+++ b/config/hypershift-operator/operator-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: hypershift-operator

--- a/hypershift-operator/assets/controlplane/hypershift/etcd/etcd-operator-cluster-role-binding.yaml
+++ b/hypershift-operator/assets/controlplane/hypershift/etcd/etcd-operator-cluster-role-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: etcd-operator

--- a/hypershift-operator/assets/controlplane/hypershift/etcd/etcd-operator-cluster-role.yaml
+++ b/hypershift-operator/assets/controlplane/hypershift/etcd/etcd-operator-cluster-role.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: etcd-operator


### PR DESCRIPTION
Currently `make install` results in the following warnings when applying rbac resources
```
W0111 14:44:40.238479   59180 warnings.go:67] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
```

This PR updates the definitions to use `rbac.authorization.k8s.io/v1`
