### PR TITLE
Fix delete

### DIFF
--- a/hypershift-operator/controllers/infra.go
+++ b/hypershift-operator/controllers/infra.go
@@ -402,10 +402,8 @@ func getRouteAddress(client ctrl.Client, ctx context.Context, key ctrl.ObjectKey
 		return "", fmt.Errorf("failed to get route: %w", err)
 	}
 	var addr string
-	if len(route.Status.Ingress) > 0 {
-		if len(route.Status.Ingress[0].Host) > 0 {
-			addr = route.Status.Ingress[0].Host
-		}
+	if len(route.Spec.Host) > 0 {
+		addr = route.Spec.Host
 	}
 	return addr, nil
 }


### PR DESCRIPTION
This lets the nodePool controller to explicitly delete its owned machineSet. Removing the owner ref is not enough as it has other from the cluster resource.

It also move the default nodePool to be created by the openshiftCluster controller. Otherwise openshiftCluster deletion is not able to delete de default nodePool.

We are blocking hcp controller on https://github.com/openshift-hive/hypershift/blob/main/hypershift-operator/controllers/infra.go#L42 though the ign endpoint will only be given after deploying the service which is only applied after that https://github.com/openshift-hive/hypershift/blob/main/hypershift-operator/controllers/hosted_controlplane_controller.go#L156
This results in a deadlock loop which is broken by this PR.

Remove foreground deletion and relax timeouts for e2e

